### PR TITLE
fixed issue #5 due to UTF-16 encoding

### DIFF
--- a/MscrmTools.PortalCodeEditor/AppCode/CodeItem.cs
+++ b/MscrmTools.PortalCodeEditor/AppCode/CodeItem.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xrm.Sdk;
 using System;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
@@ -50,7 +51,11 @@ namespace MscrmTools.PortalCodeEditor.AppCode
             if (isEncoded)
             {
                 encodedContent = data;
-                content = Encoding.UTF8.GetString(Convert.FromBase64String(data));
+                // use StreamReader to auto-detect encoding
+                using (var stream = new StreamReader(new MemoryStream(Convert.FromBase64String(data)), true))
+                {
+                    content = stream.ReadToEnd();
+                }
             }
             else
             {


### PR DESCRIPTION
The code was using UTF-8 to load the web file content which doesn't work since some files are encoded with different Unicode encoding (in this case UTF-16). StreamReader is used to auto-detect the encoding. Note that it is not bullet proof and might not work if the file encoding is not Unicode. 